### PR TITLE
bump @phila/pinboard to 2.7.2 for 2025 imagery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log*
 *.sln
 *.sw?
 .npmrc
+CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/pro-regular-svg-icons": "^6.7.2",
         "@fortawesome/pro-solid-svg-icons": "^6.7.2",
         "@phila/phila-ui-core": "^1.0.18",
-        "@phila/pinboard": "2.6.18",
+        "@phila/pinboard": "2.7.2",
         "unplugin-auto-import": "^0.18.3",
         "unplugin-vue-router": "^0.10.8",
         "vue-i18n": "^11.0.1"
@@ -1971,9 +1971,9 @@
       }
     },
     "node_modules/@phila/pinboard": {
-      "version": "2.6.18",
-      "resolved": "https://registry.npmjs.org/@phila/pinboard/-/pinboard-2.6.18.tgz",
-      "integrity": "sha512-WH358dTYSdEr7sildnj4a46tA1baI0Rr8/FFKdX/oKkcV6hkaKcy8H6s+GGnv2dEFZryJFV3II4ths0cskSZRg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@phila/pinboard/-/pinboard-2.7.2.tgz",
+      "integrity": "sha512-HQiwBiAQtr9gXmLCE1cNZWzMnbVZS6QohIb2sV7iYE9vTmdneInbl96BnjsZk2ZyC8Ks594iN3rerJAQIt2ebA==",
       "license": "MIT",
       "dependencies": {
         "@creativebulma/bulma-tooltip": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@fortawesome/pro-regular-svg-icons": "^6.7.2",
     "@fortawesome/pro-solid-svg-icons": "^6.7.2",
     "@phila/phila-ui-core": "^1.0.18",
-    "@phila/pinboard": "2.6.18",
+    "@phila/pinboard": "2.7.2",
     "unplugin-auto-import": "^0.18.3",
     "unplugin-vue-router": "^0.10.8",
     "vue-i18n": "^11.0.1"


### PR DESCRIPTION
Updates pinboard to 2.7.2 which switches to 2025 imagery (CityImagery_2025_3in).